### PR TITLE
Allow custom spawn points in game.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 npm-debug.log
+.idea/
+.vscode/

--- a/index.js
+++ b/index.js
@@ -78,6 +78,10 @@ GameEngine.prototype.createGameFromMap = function (mapFilePath){
                 game.addHealthWell(j,k);
             } else if (map[j][k] === 'IM'){
                 game.addImpassable(j,k);
+            } else if (map[j][k] === 'S1') {
+                game.addSpawnPoint(j, k, 'S1');
+            } else if (map[j][k] === 'S2') {
+                game.addSpawnPoint(j, k, 'S2');
             }
         }
     }
@@ -118,7 +122,9 @@ GameEngine.prototype.planAllGames = function (originalUsers) {
 
     // Create games
     for (gameIndex; gameIndex<numberOfGames; gameIndex++) {
-        map = me.pickMap();
+        do {
+            map = me.pickMap();
+        } while (!me.validateMap(map, maxUsersPerTeam));
         game = me.createGameFromMap( __dirname + '/lib/maps/' + map );
         game.maxTurn = me.configs.maxTurns;
         games.push(game);
@@ -201,5 +207,22 @@ GameEngine.prototype.pickMap = function () {
     }
 };
 
+GameEngine.prototype.validateMap = function (map, maxUsersPerTeam) {
+    var hasSpawnPoints = false;
+    var spawnPoints1 = 0;
+    var spawnPoints2 = 0;
+    for (var j = 0; j < map.length; j++){
+        for (var k = 0; k < map.length; k++){
+            if (map[j][k] === 'S1') {
+                hasSpawnPoints = true;
+                spawnPoints1++;
+            } else if (map[j][k] === 'S2') {
+                hasSpawnPoints = true;
+                spawnPoints2++;
+            }
+        }
+    }
+    return hasSpawnPoints ? (spawnPoints1 >= maxUsersPerTeam && spawnPoints2 >= maxUsersPerTeam) : true;
+};
 
 module.exports = GameEngine;

--- a/lib/game_classes/Game.js
+++ b/lib/game_classes/Game.js
@@ -29,6 +29,7 @@ var Game = function (n) {
     this.diamondMines = [];
     this.healthWells = [];
     this.impassables = [];
+    this.spawnPoints = [];
     this.ended = false;
 
   // Results
@@ -53,45 +54,63 @@ var Game = function (n) {
     this.gameNumber;
 };
 
-// Adds a new hero to the board
-// but ONLY if the game has not yet
-// started
+Game.prototype.addHeroToGame = function (distanceFromTop, distanceFromLeft, name, team, id) {
+    // Creates new hero object
+    var hero = new Hero(distanceFromTop, distanceFromLeft, name, team);
+    
+    // First hero added is the active hero
+    if (id === 0 || this.heroes.length === 0) {
+        this.activeHero = hero;
+    }
+
+    // Saves hero id
+    if (id === 0 || id > 0) {
+        hero.id = id;
+    } else {
+        hero.id = this.heroes.length;
+    }
+
+    // Puts hero on board
+    this.board.tiles[distanceFromTop][distanceFromLeft] = hero;
+
+    // Adds hero to game data structure
+    this.heroes.push(hero);
+
+    // Assign hero to appropriate team
+    this.teams[hero.team].push(hero);
+
+    // Makes it clear adding the hero was a success
+    return true;
+};
+
+ /* 
+    Adds a new hero to the game only if game has not started yet.
+    If map has spawn points then we can add hero only in spawn locations defined for hero's team.
+    If there are no spawn points in map, we can add hero in any Unoccupied space. 
+*/
 Game.prototype.addHero = function (distanceFromTop, distanceFromLeft, name, team, id) {
     if (this.hasStarted) {
         throw new Error('Cannot add heroes after the game has started!');
     }
-
-  // Can only add a hero to unoccupied spaces
-    if (this.board.tiles[distanceFromTop][distanceFromLeft].type === 'Unoccupied') {
-    // Creates new hero object
-        var hero = new Hero(distanceFromTop, distanceFromLeft, name, team);
-
-    // First hero added is the active hero
-        if (id === 0 || this.heroes.length === 0) {
-            this.activeHero = hero;
+    var tile = this.board.tiles[distanceFromTop][distanceFromLeft];
+    if (this.spawnPoints.length > 0) {
+        // Map has spawn points so we will try to add hero only in spawn points
+        if (tile.type === 'Unoccupied' && tile.subType === 'SpawnPoint') {
+            if (tile.spawnValue === 'S1' && team === 0) {
+                this.addHeroToGame(distanceFromTop, distanceFromLeft, name, team, id);
+                return true;
+            } else if (tile.spawnValue === 'S2' && team === 1) {
+                this.addHeroToGame(distanceFromTop, distanceFromLeft, name, team, id);
+                return true;
+            }
+            return false;
         }
-
-    // Saves hero id
-        if (id === 0 || id > 0) {
-            hero.id = id;
-        } else {
-            hero.id = this.heroes.length;
-        }
-
-    // Puts hero on board
-        this.board.tiles[distanceFromTop][distanceFromLeft] = hero;
-
-    // Adds hero to game data structure
-        this.heroes.push(hero);
-
-    // Assign hero to appropriate team
-        this.teams[hero.team].push(hero);
-
-    // Makes it clear adding the hero was a success
+    } else if (tile.type === 'Unoccupied') {
+        // Map has no spawn points so we can add hero in any unoccupied space
+        this.addHeroToGame(distanceFromTop, distanceFromLeft, name, team, id);
         return true;
-    } else {
-        return false;
     }
+    return false;
 };
 
 // Adds a diamond mine to the board
@@ -150,6 +169,27 @@ Game.prototype.addImpassable = function (distanceFromTop, distanceFromLeft) {
 
     // Adds impassable to game data structure
         this.impassables.push(impassable);
+    }
+};
+
+// Adds a spawn point to map with (S1, S2) as subTypes
+Game.prototype.addSpawnPoint = function (distanceFromTop, distanceFromLeft, spawnValue) {
+    if (this.hasStarted) {
+        throw new Error('Cannot add impassables after the game has started!');
+    }
+    // Can only add an spawn point to unoccupied spaces are not spawn points 
+    if (
+        this.board.tiles[distanceFromTop][distanceFromLeft].type === 'Unoccupied' &&
+        this.board.tiles[distanceFromTop][distanceFromLeft].subType !== 'SpawnPoint'
+    ) {
+    // Creates new Unoccupied object with spawn value
+        var spawnPoint = new Unoccupied(distanceFromTop, distanceFromLeft, spawnValue);
+
+    // Puts impassable on board
+        this.board.tiles[distanceFromTop][distanceFromLeft] = spawnPoint;
+
+    // Adds spawn points to game data structure
+        this.spawnPoints.push(spawnPoint);
     }
 };
 
@@ -231,7 +271,7 @@ Game.prototype.handleHeroTurn = function (direction) {
         }
     }
 
-  // Save the win or loss directly on the hero objects
+    // Save the win or loss directly on the hero objects
     if (this.ended) {
         for (var i=0; i<this.heroes.length; i++) {
             hero = this.heroes[i];

--- a/lib/game_classes/Unoccupied.js
+++ b/lib/game_classes/Unoccupied.js
@@ -1,6 +1,11 @@
-var Unoccupied = function (distanceFromTop, distanceFromLeft) {
+var Unoccupied = function (distanceFromTop, distanceFromLeft, sp) {
     this.type = "Unoccupied";
-    this.subType = "Unoccupied";
+    if (sp) {
+        this.subType = "SpawnPoint";
+        this.spawnValue = sp;
+    } else {
+        this.subType = "Unoccupied";        
+    }
     this.distanceFromTop = distanceFromTop;
     this.distanceFromLeft = distanceFromLeft;
 };


### PR DESCRIPTION
## Purpose
+ Basic draft for adding custom spawn points in game. #12 

+ Created an early PR so that you can check the implementation logic and code organization part, once that is done I can start writing test cases. 

## Description of changes

+ **Validating Map**: While calculating the number of games required, we use a variable `maxUsersPerTeam`, same variable is used to validate a randomly chosen map. (Example: If `maxUsersPerTeam` is 4, in this case number of spawn points should be at least 4 for each team or 0 overall), if a map doesn't satisfy these conditions we will randomly choose another map till we have the required number of maps.

+ **Adding Hero**:  If map has spawn points then we can add hero only in spawn locations defined for hero's team, If there are no spawn points in map, we can add hero in any Unoccupied space. 

+ **Unoccupied**: has now a new `subType`: `SpawnPoint` and `spawnValue`: `S1` or `S2`

cc: @Asuza 